### PR TITLE
Update GitHub username references

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To use real Spotify authentication and playback:
 1. Create a Spotify application in the Spotify Developer Dashboard.
 2. Add Redirect URIs:
    - Local dev: `http://127.0.0.1:8000/callback`
-   - GitHub Pages: `https://stags420.github.io/walkup_music/callback`
+   - GitHub Pages: `https://stagswtf.github.io/walkup_music/callback`
 3. Copy `.env.local.example` to `.env.local` and set:
    - `VITE_SPOTIFY_CLIENT_ID=<your-client-id>`
    - Optionally, `VITE_BASE_PATH` and `VITE_MOCK_AUTH`
@@ -246,7 +246,7 @@ Deployment uses the `gh-pages` package and the `deploy` script:
 npm run deploy
 ```
 
-This builds the app, runs tests, and publishes `dist/` to the `gh-pages` branch. The site is served at `https://stags420.github.io/walkup_music/`.
+This builds the app, runs tests, and publishes `dist/` to the `gh-pages` branch. The site is served at `https://stagswtf.github.io/walkup_music/`.
 
 If you fork this repo, update `homepage` in `package.json` and `base` in `vite.config.ts` to match your GitHub Pages path.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://stags420.github.io/walkup_music",
+  "homepage": "https://stagswtf.github.io/walkup_music",
   "scripts": {
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --report-unused-disable-directives --max-warnings 0 --fix",

--- a/src/defaultAppConfig.ts
+++ b/src/defaultAppConfig.ts
@@ -11,7 +11,7 @@ export const detectBasePath = (): string => {
   const hostname = globalThis.location.hostname;
 
   // For GitHub Pages deployment, always use /walkup_music (no trailing slash for React Router)
-  if (hostname === 'stags420.github.io') {
+  if (hostname === 'stagswtf.github.io') {
     return '/walkup_music';
   }
 


### PR DESCRIPTION
## Summary
- update homepage URL to use the new GitHub username stagswtf
- refresh README links and callback URL for the new username
- adjust GitHub Pages hostname detection in the default app config

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdc402af0c832b81ac3dcb8954120a