### PR TITLE
Update charliehooks comments and auto-merge

### DIFF
--- a/hooks/charliehooks/src/github.ts
+++ b/hooks/charliehooks/src/github.ts
@@ -145,7 +145,7 @@ export function deriveTransitionFromGithubWebhook(options: {
     return {
       issueIdentifiers: identifiers,
       targetStateName: 'Merged',
-      comment: 'Auto-moved via GitHub pull_request merged webhook.',
+      comment: 'CR Merged, awaiting deployment',
     };
   }
 
@@ -183,7 +183,8 @@ export function deriveTransitionFromGithubWebhook(options: {
     return {
       issueIdentifiers: identifiers,
       targetStateName: 'Delivered',
-      comment: 'Auto-moved via GitHub workflow_run deploy success webhook.',
+      comment:
+        'Charlie, the code is deployed for this task. Go verify it in production and send proof it works via screenshot. If you verify success, move the task to accepted. If you find an issue, note the bug in the issue and put the issue back to ready.',
     };
   }
 

--- a/hooks/charliehooks/src/github.ts
+++ b/hooks/charliehooks/src/github.ts
@@ -7,6 +7,22 @@ export type GithubDerivedTransition = {
   comment: string;
 };
 
+export type GithubAutoMergeRequest = {
+  issueIdentifiers: string[];
+  pullRequestId: string;
+  pullRequestNumber: number;
+  repositoryFullName: string;
+};
+
+type GithubGraphqlError = {
+  message: string;
+};
+
+type GithubGraphqlResponse<TData> = {
+  data?: TData;
+  errors?: GithubGraphqlError[];
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -93,6 +109,128 @@ export function verifyGithubSignature(options: {
   }
 
   return timingSafeEqual(expected, actual);
+}
+
+export function deriveAutoMergeRequestFromGithubWebhook(options: {
+  eventName: string | undefined;
+  payload: unknown;
+  teamKey: string;
+  mainBranch: string;
+}): GithubAutoMergeRequest | undefined {
+  if (options.eventName !== 'pull_request') {
+    return;
+  }
+
+  const payload: unknown = options.payload;
+  if (!isRecord(payload)) {
+    return;
+  }
+
+  const action: unknown = payload.action;
+  if (action !== 'opened' && action !== 'ready_for_review' && action !== 'reopened') {
+    return;
+  }
+
+  const pr: unknown = payload.pull_request;
+  if (!isRecord(pr)) {
+    return;
+  }
+
+  const draft: unknown = pr.draft;
+  if (draft === true) {
+    return;
+  }
+
+  const base: unknown = pr.base;
+  if (!isRecord(base)) {
+    return;
+  }
+
+  const baseRef: unknown = base.ref;
+  if (typeof baseRef !== 'string' || baseRef !== options.mainBranch) {
+    return;
+  }
+
+  const pullRequestId: unknown = pr.node_id;
+  const pullRequestNumber: unknown = pr.number;
+  const repository: unknown = payload.repository;
+  const repositoryFullName: unknown = isRecord(repository) ? repository.full_name : undefined;
+  if (
+    typeof pullRequestId !== 'string' ||
+    typeof pullRequestNumber !== 'number' ||
+    !Number.isInteger(pullRequestNumber) ||
+    typeof repositoryFullName !== 'string'
+  ) {
+    return;
+  }
+
+  const identifiers: string[] = extractLinearIssueIdentifiers(payload, options.teamKey);
+  if (identifiers.length === 0) {
+    return;
+  }
+
+  return {
+    issueIdentifiers: identifiers,
+    pullRequestId,
+    pullRequestNumber,
+    repositoryFullName,
+  };
+}
+
+async function githubGraphql<TData>(
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<TData> {
+  const timeoutMs = 10_000;
+  const response: Response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'charliehooks',
+      Accept: 'application/vnd.github+json',
+    },
+    body: JSON.stringify({ query, variables }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL HTTP ${response.status}`);
+  }
+
+  const payloadUnknown: unknown = await response.json();
+  const payload: GithubGraphqlResponse<TData> = payloadUnknown as GithubGraphqlResponse<TData>;
+  if (payload.errors && payload.errors.length > 0) {
+    const messages: string = payload.errors.map((error) => error.message).join('; ');
+    throw new Error(`GitHub GraphQL error: ${messages}`);
+  }
+
+  if (!payload.data) {
+    throw new Error('GitHub GraphQL error: missing data');
+  }
+
+  return payload.data;
+}
+
+export async function enablePullRequestAutoMerge(options: {
+  token: string;
+  pullRequestId: string;
+  dryRun?: boolean;
+}): Promise<void> {
+  if (options.dryRun) {
+    console.log(`[dry-run] GitHub auto-merge enabled for ${options.pullRequestId}`);
+    return;
+  }
+
+  const mutation =
+    'mutation($pullRequestId:ID!){ enablePullRequestAutoMerge(input:{pullRequestId:$pullRequestId, mergeMethod:SQUASH}) { pullRequest { id number } } }';
+
+  await githubGraphql<{
+    enablePullRequestAutoMerge: {
+      pullRequest: { id: string; number: number } | null;
+    } | null;
+  }>(options.token, mutation, { pullRequestId: options.pullRequestId });
 }
 
 export function deriveTransitionFromGithubWebhook(options: {

--- a/hooks/charliehooks/src/github.ts
+++ b/hooks/charliehooks/src/github.ts
@@ -14,6 +14,8 @@ export type GithubAutoMergeRequest = {
   repositoryFullName: string;
 };
 
+export type GithubPullRequestIntegrationResult = 'auto-merge-enabled' | 'merged';
+
 type GithubGraphqlError = {
   message: string;
 };
@@ -217,20 +219,39 @@ export async function enablePullRequestAutoMerge(options: {
   token: string;
   pullRequestId: string;
   dryRun?: boolean;
-}): Promise<void> {
+}): Promise<GithubPullRequestIntegrationResult> {
   if (options.dryRun) {
     console.log(`[dry-run] GitHub auto-merge enabled for ${options.pullRequestId}`);
-    return;
+    return 'auto-merge-enabled';
   }
 
   const mutation =
     'mutation($pullRequestId:ID!){ enablePullRequestAutoMerge(input:{pullRequestId:$pullRequestId, mergeMethod:SQUASH}) { pullRequest { id number } } }';
 
+  try {
+    await githubGraphql<{
+      enablePullRequestAutoMerge: {
+        pullRequest: { id: string; number: number } | null;
+      } | null;
+    }>(options.token, mutation, { pullRequestId: options.pullRequestId });
+    return 'auto-merge-enabled';
+  } catch (error: unknown) {
+    const message: string = error instanceof Error ? error.message : String(error);
+    if (!message.includes('Pull request is in clean status')) {
+      throw error;
+    }
+  }
+
+  const mergeMutation =
+    'mutation($pullRequestId:ID!){ mergePullRequest(input:{pullRequestId:$pullRequestId, mergeMethod:SQUASH}) { pullRequest { id number merged } } }';
+
   await githubGraphql<{
-    enablePullRequestAutoMerge: {
-      pullRequest: { id: string; number: number } | null;
+    mergePullRequest: {
+      pullRequest: { id: string; number: number; merged: boolean } | null;
     } | null;
-  }>(options.token, mutation, { pullRequestId: options.pullRequestId });
+  }>(options.token, mergeMutation, { pullRequestId: options.pullRequestId });
+
+  return 'merged';
 }
 
 export function deriveTransitionFromGithubWebhook(options: {

--- a/hooks/charliehooks/src/server.ts
+++ b/hooks/charliehooks/src/server.ts
@@ -12,6 +12,7 @@ import {
   verifyGithubSignature,
   type GithubAutoMergeRequest,
   type GithubDerivedTransition,
+  type GithubPullRequestIntegrationResult,
 } from './github.js';
 import {
   addIssueComment,
@@ -297,12 +298,17 @@ async function handleGithubWebhook(
   let autoMergeStatus: string | undefined;
   if (autoMergeRequest) {
     if (githubToken) {
-      await enablePullRequestAutoMerge({
+      const integrationResult: GithubPullRequestIntegrationResult = await enablePullRequestAutoMerge({
         token: githubToken,
         pullRequestId: autoMergeRequest.pullRequestId,
         dryRun: client.dryRun,
       });
-      autoMergeStatus = client.dryRun ? 'dry-run' : 'enabled';
+      if (client.dryRun) {
+        autoMergeStatus = 'dry-run';
+      } else {
+        autoMergeStatus =
+          integrationResult === 'merged' ? 'merged-immediately' : 'enabled';
+      }
     } else {
       autoMergeStatus = 'missing-token';
       console.warn(

--- a/hooks/charliehooks/src/server.ts
+++ b/hooks/charliehooks/src/server.ts
@@ -2,10 +2,15 @@ import { createServer } from 'node:http';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Buffer } from 'node:buffer';
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import {
+  deriveAutoMergeRequestFromGithubWebhook,
   deriveTransitionFromGithubWebhook,
+  enablePullRequestAutoMerge,
   verifyGithubSignature,
+  type GithubAutoMergeRequest,
   type GithubDerivedTransition,
 } from './github.js';
 import {
@@ -27,6 +32,15 @@ import {
 } from './acceptance.js';
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+const SECRET_DIR = '/run/app-secrets';
+const SECRET_FILE_NAMES: Record<string, string[]> = {
+  CHARLIEHOOKS_INTERNAL_SECRET: ['charliehooks_internal_secret'],
+  GITHUB_PR_PAT: ['github_pr_pat'],
+  GITHUB_TOKEN: ['github_token', 'github_pr_pat'],
+  GITHUB_WEBHOOK_SECRET: ['github_webhook_secret'],
+  LINEAR_API_KEY: ['linear_api_key'],
+  LINEAR_WEBHOOK_SECRET: ['linear_webhook_secret'],
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -78,9 +92,33 @@ function parseJsonBody(body: Buffer): unknown {
   return JSON.parse(text) as unknown;
 }
 
+function readSecretFile(name: string): string | undefined {
+  const fileNames: string[] = SECRET_FILE_NAMES[name] ?? [name.toLowerCase()];
+  for (const fileName of fileNames) {
+    try {
+      const value: string = readFileSync(join(SECRET_DIR, fileName), 'utf8').trim();
+      if (value.length > 0) {
+        return value;
+      }
+    } catch (error: unknown) {
+      const code: string | undefined =
+        isRecord(error) && typeof error.code === 'string' ? error.code : undefined;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        throw error;
+      }
+    }
+  }
+
+  return;
+}
+
 function getEnv(name: string): string | undefined {
   const value: string | undefined = process.env[name];
-  return value && value.length > 0 ? value : undefined;
+  if (value && value.length > 0) {
+    return value;
+  }
+
+  return readSecretFile(name);
 }
 
 function getRequiredEnv(name: string): string {
@@ -213,8 +251,8 @@ async function handleGithubWebhook(
   req: IncomingMessage,
   res: ServerResponse,
   client: LinearClient,
-  defaultProdUrl: string,
   mainBranch: string,
+  githubToken: string | undefined,
 ): Promise<void> {
   const body: Buffer = await readRequestBody(req);
   const eventName: string | undefined = getHeader(req, 'x-github-event');
@@ -238,6 +276,12 @@ async function handleGithubWebhook(
     return;
   }
 
+  const autoMergeRequest: GithubAutoMergeRequest | undefined = deriveAutoMergeRequestFromGithubWebhook({
+    eventName,
+    payload,
+    teamKey: client.teamKey,
+    mainBranch,
+  });
   const transition: GithubDerivedTransition | undefined = deriveTransitionFromGithubWebhook({
     eventName,
     payload,
@@ -245,18 +289,57 @@ async function handleGithubWebhook(
     mainBranch,
   });
 
-  if (!transition) {
+  let autoMergeStatus: string | undefined;
+  if (autoMergeRequest) {
+    if (githubToken) {
+      await enablePullRequestAutoMerge({
+        token: githubToken,
+        pullRequestId: autoMergeRequest.pullRequestId,
+        dryRun: client.dryRun,
+      });
+      autoMergeStatus = client.dryRun ? 'dry-run' : 'enabled';
+    } else {
+      autoMergeStatus = 'missing-token';
+      console.warn(
+        `GitHub auto-merge skipped for PR #${autoMergeRequest.pullRequestNumber}: missing GitHub token`,
+      );
+    }
+  }
+
+  if (!transition && !autoMergeRequest) {
     jsonResponse(res, 200, { ok: true, action: 'noop' });
     return;
   }
 
-  await applyGithubDerivedTransition(client, transition);
-  jsonResponse(res, 200, {
+  if (transition) {
+    await applyGithubDerivedTransition(client, transition);
+  }
+
+  const responseBody: {
+    ok: boolean;
+    action: string;
+    state?: string;
+    issues?: string[];
+    autoMerge?: string;
+    pullRequestNumber?: number;
+  } = {
     ok: true,
-    action: 'updated',
-    state: transition.targetStateName,
-    issues: transition.issueIdentifiers,
-  });
+    action: transition ? 'updated' : 'auto-merge',
+  };
+
+  if (transition) {
+    responseBody.state = transition.targetStateName;
+    responseBody.issues = transition.issueIdentifiers;
+  }
+  if (autoMergeStatus) {
+    responseBody.autoMerge = autoMergeStatus;
+  }
+  if (autoMergeRequest) {
+    responseBody.pullRequestNumber = autoMergeRequest.pullRequestNumber;
+    responseBody.issues = responseBody.issues ?? autoMergeRequest.issueIdentifiers;
+  }
+
+  jsonResponse(res, 200, responseBody);
 }
 
 async function handleVerifyAndAccept(
@@ -472,6 +555,7 @@ async function handleLinearWebhook(
 
 export function startServer(): void {
   const linearApiKey: string = getRequiredEnv('LINEAR_API_KEY');
+  const githubToken: string | undefined = getEnv('GITHUB_TOKEN') ?? getEnv('GITHUB_PR_PAT');
   const teamKey: string = getEnv('LINEAR_TEAM_KEY') ?? 'CHA';
   const defaultProdUrl: string = getEnv('CHARLIEHOOKS_DEFAULT_PROD_URL') ??
     'https://stagswtf.github.io/walkup_music/';
@@ -508,7 +592,7 @@ export function startServer(): void {
     }
 
     if (method === 'POST' && url.pathname === '/github') {
-      await handleGithubWebhook(req, res, client, defaultProdUrl, mainBranch);
+      await handleGithubWebhook(req, res, client, mainBranch, githubToken);
       return;
     }
 

--- a/hooks/charliehooks/src/server.ts
+++ b/hooks/charliehooks/src/server.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Buffer } from 'node:buffer';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import path from 'node:path';
 
 import {
   deriveAutoMergeRequestFromGithubWebhook,
@@ -96,7 +96,7 @@ function readSecretFile(name: string): string | undefined {
   const fileNames: string[] = SECRET_FILE_NAMES[name] ?? [name.toLowerCase()];
   for (const fileName of fileNames) {
     try {
-      const value: string = readFileSync(join(SECRET_DIR, fileName), 'utf8').trim();
+      const value: string = readFileSync(path.join(SECRET_DIR, fileName), 'utf8').trim();
       if (value.length > 0) {
         return value;
       }
@@ -171,16 +171,21 @@ function verifyLinearSignature(options: {
 
 function getInstructionCommentForState(stateName: string): string | undefined {
   switch (stateName) {
-    case 'Intake':
+    case 'Intake': {
       return 'Charlie, proceed with plan and breakdown of this requeset into appropriately sized tasks with blockers linked. Put those tasks in the backlog. Once you have finished creating all tasks, move them all to ready.';
-    case 'Ready':
+    }
+    case 'Ready': {
       return 'Charlie, proceed with implementation. First move the task to in progress.';
-    case 'Merged':
+    }
+    case 'Merged': {
       return 'CR Merged, awaiting deployment';
-    case 'Delivered':
+    }
+    case 'Delivered': {
       return 'Charlie, the code is deployed for this task. Go verify it in production and send proof it works via screenshot. If you verify success, move the task to accepted. If you find an issue, note the bug in the issue and put the issue back to ready.';
-    default:
+    }
+    default: {
       return;
+    }
   }
 }
 
@@ -519,13 +524,9 @@ async function handleLinearWebhook(
       return;
     }
 
-    let oldStateName: string | undefined;
     let newStateName: string | undefined;
     try {
-      [oldStateName, newStateName] = await Promise.all([
-        getWorkflowStateNameById(client, oldStateId),
-        getWorkflowStateNameById(client, newStateId),
-      ]);
+      newStateName = await getWorkflowStateNameById(client, newStateId);
     } catch (error: unknown) {
       console.warn(`Could not resolve workflow state names: ${String(error)}`);
     }

--- a/hooks/charliehooks/src/server.ts
+++ b/hooks/charliehooks/src/server.ts
@@ -131,6 +131,21 @@ function verifyLinearSignature(options: {
   return timingSafeEqual(expected, actual);
 }
 
+function getInstructionCommentForState(stateName: string): string | undefined {
+  switch (stateName) {
+    case 'Intake':
+      return 'Charlie, proceed with plan and breakdown of this requeset into appropriately sized tasks with blockers linked. Put those tasks in the backlog. Once you have finished creating all tasks, move them all to ready.';
+    case 'Ready':
+      return 'Charlie, proceed with implementation. First move the task to in progress.';
+    case 'Merged':
+      return 'CR Merged, awaiting deployment';
+    case 'Delivered':
+      return 'Charlie, the code is deployed for this task. Go verify it in production and send proof it works via screenshot. If you verify success, move the task to accepted. If you find an issue, note the bug in the issue and put the issue back to ready.';
+    default:
+      return;
+  }
+}
+
 async function applyGithubDerivedTransition(
   client: LinearClient,
   transition: GithubDerivedTransition,
@@ -150,7 +165,9 @@ async function applyGithubDerivedTransition(
       await setIssueState(client, identifier, transition.targetStateName);
     }
 
-    await addIssueComment(client, identifier, transition.comment);
+    if (transition.comment.length > 0) {
+      await addIssueComment(client, identifier, transition.comment);
+    }
   }
 }
 
@@ -240,20 +257,6 @@ async function handleGithubWebhook(
     state: transition.targetStateName,
     issues: transition.issueIdentifiers,
   });
-
-  if (transition.targetStateName === 'Delivered') {
-    void (async () => {
-      for (const issueIdentifier of transition.issueIdentifiers) {
-        await verifyAndAcceptIssue({
-          client,
-          issueIdentifier,
-          defaultProdUrl,
-        });
-      }
-    })().catch((error: unknown) => {
-      console.error(`verifyAndAcceptIssue failed after Delivered: ${String(error)}`);
-    });
-  }
 }
 
 async function handleVerifyAndAccept(
@@ -387,13 +390,6 @@ async function handleLinearWebhook(
     return;
   }
 
-  const actorName: string | undefined =
-    isRecord(payloadUnknown.actor) && typeof payloadUnknown.actor.name === 'string'
-      ? payloadUnknown.actor.name
-      : undefined;
-
-  const issueUrl: string | undefined =
-    typeof payloadUnknown.url === 'string' ? payloadUnknown.url : undefined;
   const issueIdentifier: string | undefined =
     typeof data.identifier === 'string' ? data.identifier : undefined;
   const issueId: string | undefined = typeof data.id === 'string' ? data.id : undefined;
@@ -412,12 +408,18 @@ async function handleLinearWebhook(
     }
   }
 
-  jsonResponse(res, 200, {
+  const responseBody: { ok: boolean; action: string; issueId?: string; issueIdentifier?: string } = {
     ok: true,
     action: 'queued',
-    issueId,
-    issueIdentifier,
-  });
+  };
+  if (issueId) {
+    responseBody.issueId = issueId;
+  }
+  if (issueIdentifier) {
+    responseBody.issueIdentifier = issueIdentifier;
+  }
+
+  jsonResponse(res, 200, responseBody);
 
   void (async () => {
     if (!issueId) {
@@ -445,16 +447,17 @@ async function handleLinearWebhook(
       console.warn(`Could not resolve workflow state names: ${String(error)}`);
     }
 
-    const mention: string = getEnv('CHARLIEHOOKS_LINEAR_MENTION') ?? '@charlie';
-    const byText: string = actorName ? ` by ${actorName}` : '';
-    const fromText: string = oldStateName ?? oldStateId;
-    const toText: string = newStateName ?? newStateId;
-    const urlText: string = issueUrl ? `\n\n${issueUrl}` : '';
+    const comment: string | undefined = newStateName
+      ? getInstructionCommentForState(newStateName)
+      : undefined;
+    if (!comment) {
+      return;
+    }
 
     await addIssueCommentById(
       client,
       issueId,
-      `${mention} ${resolvedIdentifier}: State transition${byText}: ${fromText} -> ${toText}.${urlText}`,
+      comment,
     );
   })().catch((error: unknown) => {
     console.error(


### PR DESCRIPTION
## Summary
- add Charlie stage-instruction comments for Intake, Ready, Merged, and Delivered
- read hook secrets from `/run/app-secrets` so `github_pr_pat` works like `linear_api_key`
- enable GitHub auto-merge for matching PRs on open/ready events

## Testing
- `npx tsc /Users/stags/workspace/walkup_music/hooks/charliehooks/src/*.ts --outDir /tmp/charliehooks-latest --rootDir /Users/stags/workspace/walkup_music/hooks/charliehooks/src --module NodeNext --moduleResolution NodeNext --target ES2022 --lib ES2022,DOM --types node --strict --skipLibCheck --esModuleInterop --allowSyntheticDefaultImports`
- local dry-run webhook tests for Delivered, Intake, Ready, Merged, and Backlog silence